### PR TITLE
Add window spanning scripts

### DIFF
--- a/span-left.sh
+++ b/span-left.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+current_x=$(xwininfo -id "$(xdotool getactivewindow)" | grep "Absolute upper-left X" | awk '{print $NF}')
+
+if [ "$current_x" -ge 1680 ]
+then
+  screen_offset=1680
+else
+  screen_offset=0
+fi
+wmctrl -r :ACTIVE: -e 0,$screen_offset,0,840,1050

--- a/span-right.sh
+++ b/span-right.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+current_x=$(xwininfo -id "$(xdotool getactivewindow)" | grep "Absolute upper-left X" | awk '{print $NF}')
+
+if [ "$current_x" -ge 1680 ]
+then
+  screen_offset=$((1680 + 840))
+else
+  screen_offset=840
+fi
+wmctrl -r :ACTIVE: -e 0,$screen_offset,0,840,1050


### PR DESCRIPTION
Hi @gentooboontoo, could you give me some advice, a helping hand on this please ? :smiley: 

This is only a draft, unshippable in this state, but I have some difficulty with the shell language :smirk: 

I would like to avoid:
- hard-coded screen resolutions
- get it working for both single/dual-monitor systems

Do you know better commands to get:
- screen resolution(s)?
- current window (horizontal) position?

What would you advise me to refactor those as a single script and pass the `left || right` info as param?

Thanks! :grin: 
